### PR TITLE
docs: add Base minikit notes

### DIFF
--- a/PRPs/ai_docs/base_minikit_notes.md
+++ b/PRPs/ai_docs/base_minikit_notes.md
@@ -1,0 +1,30 @@
+# Base Minikit Notes
+
+## Chain IDs
+- Base Mainnet: 8453
+- Base Sepolia Testnet: 84532
+
+## viem wallet connection snippets
+
+```ts
+import { createWalletClient, http } from 'viem';
+import { base, baseSepolia } from 'viem/chains';
+
+// mainnet connection
+const clientMainnet = createWalletClient({
+  chain: base,
+  transport: http(),
+});
+
+// sepolia testnet connection
+const clientSepolia = createWalletClient({
+  chain: baseSepolia,
+  transport: http(),
+});
+```
+
+## Base App embedding quirks and best practices
+- When embedding the Base App in an iframe, include `allow="clipboard-write"` so users can copy addresses.
+- Use a unique `nonce` with CSP headers when injecting scripts to satisfy security policies.
+- Handle `postMessage` events and verify `event.origin` is the expected Base domain before acting.
+- For internal navigation inside an embed, set links to `target="_parent"` to avoid nested frames.


### PR DESCRIPTION
## Summary
- document Base Mainnet (8453) and Base Sepolia (84532) chain IDs
- add viem wallet connection snippet
- outline Base App iframe embed best practices

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689c73d8adfc8331a0e393bd08efd1ce