### PR TITLE
docs: add chainlink automation base guide

### DIFF
--- a/PRPs/ai_docs/chainlink_automation_base.md
+++ b/PRPs/ai_docs/chainlink_automation_base.md
@@ -1,0 +1,31 @@
+# Chainlink Automation Base
+
+This guide introduces Chainlink Automation fundamentals for this project, including how to register an upkeep, understand costs, and deploy on test networks.
+
+## Upkeep registration
+1. Deploy a contract that implements `checkUpkeep` and `performUpkeep`.
+2. Register the contract via the [Automation UI](https://automation.chain.link) or CLI.
+3. Supply the contract address, gas limit, admin address, and any needed checkData.
+4. Fund the upkeep with LINK; a minimum balance (commonly 1 LINK) is required before execution can begin.
+5. Costs are deducted per execution: `gasUsed * gasPrice + premium`, paid in LINK from the upkeep balance.
+
+## Sample `performUpkeep` logic
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract ExampleUpkeep {
+    uint256 public counter;
+
+    function performUpkeep(bytes calldata /* performData */) external {
+        // maintenance task
+        counter += 1;
+    }
+}
+```
+
+## Testnet deployment tips
+- Use a supported test network such as Sepolia.
+- Acquire testnet ETH and LINK from faucets and fund the upkeep sufficiently.
+- Verify the upkeep registration and monitor execution through block explorers or the Automation UI.
+- Start with conservative gas limits and LINK balances, adjusting once behavior is confirmed.


### PR DESCRIPTION
## Summary
- add guide for chainlink automation registration, costs, and sample performUpkeep logic
- include tips for deploying to testnets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c73d9bb988331acaead157511db87