### PR TITLE
docs: add project initialization task prp

### DIFF
--- a/PRPs/project-initialization-task.md
+++ b/PRPs/project-initialization-task.md
@@ -1,0 +1,45 @@
+# Project Initialization Task PRP
+
+context:
+  docs:
+    - url: postschedule-appbuild.md
+      focus: Step 1 – Set Up the Farcaster Mini App
+    - url: PRPs/post-scheduler-execution.md
+      focus: Required software and environment variables
+
+CREATE .:
+  - RUN: npx create-next-app@latest . --ts --eslint --app --src-dir
+  - VALIDATE: npm run lint && npm run dev
+  - IF_FAIL: ensure Node ≥18 and reinstall dependencies
+  - ROLLBACK: git clean -fdx
+
+UPDATE package.json:
+  - ADD: @farcaster/miniapp-sdk, tailwindcss, autoprefixer, postcss
+  - RUN: npm install @farcaster/miniapp-sdk tailwindcss postcss autoprefixer
+  - VALIDATE: npm list @farcaster/miniapp-sdk
+  - IF_FAIL: reinstall dependencies
+  - ROLLBACK: npm uninstall @farcaster/miniapp-sdk tailwindcss postcss autoprefixer
+
+CREATE tailwind.config.js:
+  - RUN: npx tailwindcss init -p
+  - UPDATE: set content to './app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'
+  - VALIDATE: npm run dev
+  - IF_FAIL: verify config paths
+  - ROLLBACK: git checkout -- tailwind.config.js postcss.config.js
+
+UPDATE app/layout.tsx:
+  - ADD: Farcaster mini app metadata (<meta property="fc:frame" content="vNext" />)
+  - ADD: Open Graph tags for title and image
+  - VALIDATE: npm run build && grep -R "fc:frame" .next | head -n 1
+  - IF_FAIL: check metadata syntax and placement
+  - ROLLBACK: git checkout -- app/layout.tsx
+
+CREATE app/page.tsx:
+  - IMPLEMENT: placeholder home page linking to post composer
+  - VALIDATE: npm run dev and visit http://localhost:3000
+  - IF_FAIL: check component export
+  - ROLLBACK: git rm app/page.tsx
+
+CHECKPOINT:
+  - RUN: npm run lint && npm test
+  - IF_FAIL: fix lint/test errors before proceeding

--- a/PRPs/project-initialization-task.md
+++ b/PRPs/project-initialization-task.md
@@ -22,23 +22,29 @@ UPDATE package.json:
 
 CREATE tailwind.config.js:
   - RUN: npx tailwindcss init -p
-  - UPDATE: set content to './app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'
+  - UPDATE: set content to './src/app/**/*.{ts,tsx}', './src/components/**/*.{ts,tsx}'
   - VALIDATE: npm run dev
   - IF_FAIL: verify config paths
   - ROLLBACK: git checkout -- tailwind.config.js postcss.config.js
 
-UPDATE app/layout.tsx:
+UPDATE src/app/globals.css:
+  - ADD: Tailwind directives (@tailwind base; @tailwind components; @tailwind utilities;)
+  - VALIDATE: npm run dev
+  - IF_FAIL: ensure directives are correctly placed at top of file
+  - ROLLBACK: git checkout -- src/app/globals.css
+
+UPDATE src/app/layout.tsx:
   - ADD: Farcaster mini app metadata (<meta property="fc:frame" content="vNext" />)
   - ADD: Open Graph tags for title and image
   - VALIDATE: npm run build && grep -R "fc:frame" .next | head -n 1
   - IF_FAIL: check metadata syntax and placement
-  - ROLLBACK: git checkout -- app/layout.tsx
+  - ROLLBACK: git checkout -- src/app/layout.tsx
 
-CREATE app/page.tsx:
+CREATE src/app/page.tsx:
   - IMPLEMENT: placeholder home page linking to post composer
   - VALIDATE: npm run dev and visit http://localhost:3000
   - IF_FAIL: check component export
-  - ROLLBACK: git rm app/page.tsx
+  - ROLLBACK: git rm src/app/page.tsx
 
 CHECKPOINT:
   - RUN: npm run lint && npm test


### PR DESCRIPTION
## Summary
- add task-oriented PRP for project initialization covering Next.js scaffolding, Tailwind setup, and Farcaster metadata

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c708fe22883318e5f1e53aeaa34c0